### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Offical Meshtastic ATAK Plugin for sending CoT to IMeshService in the Meshtastic Android app.
 
 # Meshtastic Plugin Tool menu
-There is now a Meshtastic Tool menu, it currently is only used for recording Voice Memos. Voice memos will record your speech to text then send a Meshtastic text message. If users enable "Text to Speech" in preferecnes the message will be read outloud. Only English is supported currently. The Speech to Text is performed with the Vosk library.
+There is now a Meshtastic Tool menu, it currently is only used for recording Voice Memos. Voice memos will record your speech to text then send a Meshtastic text message. If users enable "Text to Speech" in preferences the message will be read outloud. Only English is supported currently. The Speech to Text is performed with the Vosk library.
 
 # Settings
 The plugin currently has the following settings:
@@ -16,7 +16,7 @@ The plugin currently has the following settings:
 - Reporting rate, the menu to pick the interval in minutes
 - Only send PLI and Chat messages, this will only use the atak.protos which are optimized for speed (no libcotshrink)
 - Use Text to Speech for incoming messages, this will read outloud any Meshtastic TEXT_MESSAGE_APP (basic meshtastic text messages)
-- PTT KeyCode, this allows you to define what hardware key to use to enable voice recording (see the Mestastic Plugin's Tool menu "Voice Memo")
+- PTT KeyCode, this allows you to define what hardware key to use to enable voice recording (see the Meshtastic Plugin's Tool menu "Voice Memo")
 - Meshtastic Channel Index, this allows you to define what channel to send ATAK messages on (0 by default)
 - Meshtastic Hop Limit, this allows you to adjust the hop limit for ATAK messages (3 by default, 8 max)
 - Allow SWITCH command, this opts-in for allowing nodes to switch your node to Short/Fast for file transfers


### PR DESCRIPTION
## Summary
- fix spelling in README.md
- ensure final newline at EOF

## Testing
- `./gradlew test` *(fails: JAVA_HOME is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_683b68e8bda4832c8763cc608b15b91f